### PR TITLE
docs: Use width="600" to match top-level Ollama readmes

### DIFF
--- a/resources/ollama/granite-embedding/README.md
+++ b/resources/ollama/granite-embedding/README.md
@@ -1,4 +1,4 @@
-<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="200" /></center>
+<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="600" /></center>
 
 ### Granite embedding models
 

--- a/resources/ollama/granite3-code/README.md
+++ b/resources/ollama/granite3-code/README.md
@@ -1,5 +1,5 @@
 
-<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="200" /></center>
+<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="600" /></center>
 
 ### Granite code models
 

--- a/resources/ollama/granite3-dense/README.md
+++ b/resources/ollama/granite3-dense/README.md
@@ -1,4 +1,4 @@
-<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="200" /></center>
+<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="600" /></center>
 
 ### Granite dense models
 

--- a/resources/ollama/granite3-guardian/README.md
+++ b/resources/ollama/granite3-guardian/README.md
@@ -1,4 +1,4 @@
-<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="200" /></center>
+<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="600" /></center>
 
 ### Granite guardian models
 

--- a/resources/ollama/granite3-moe/README.md
+++ b/resources/ollama/granite3-moe/README.md
@@ -1,4 +1,4 @@
-<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="200" /></center>
+<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="600" /></center>
 
 ### Granite dense models
 

--- a/resources/ollama/granite3.1-dense/README.md
+++ b/resources/ollama/granite3.1-dense/README.md
@@ -1,4 +1,4 @@
-<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="200" /></center>
+<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="600" /></center>
 
 ### Granite dense models
 

--- a/resources/ollama/granite3.1-guardian/README.md
+++ b/resources/ollama/granite3.1-guardian/README.md
@@ -1,4 +1,4 @@
-<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="200" /></center>
+<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="600" /></center>
 
 ### Granite guardian models
 

--- a/resources/ollama/granite3.1-moe/README.md
+++ b/resources/ollama/granite3.1-moe/README.md
@@ -1,4 +1,4 @@
-<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="200" /></center>
+<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="600" /></center>
 
 ### Granite mixture of experts models
 

--- a/resources/ollama/granite3.2-guardian/README.md
+++ b/resources/ollama/granite3.2-guardian/README.md
@@ -1,4 +1,4 @@
-<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="200" /></center>
+<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="600" /></center>
 
 ### Granite guardian models
 

--- a/resources/ollama/granite3.2-vision/README.md
+++ b/resources/ollama/granite3.2-vision/README.md
@@ -1,4 +1,4 @@
-<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="200" /></center>
+<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="600" /></center>
 
 ### Granite 3.2 Vision models
 

--- a/resources/ollama/granite3.2/README.md
+++ b/resources/ollama/granite3.2/README.md
@@ -1,4 +1,4 @@
-<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="200" /></center>
+<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="600" /></center>
 
 ### Granite 3.2 models
 

--- a/resources/ollama/granite3.3-guardian/README.md
+++ b/resources/ollama/granite3.3-guardian/README.md
@@ -1,4 +1,4 @@
-<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="200" /></center>
+<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="600" /></center>
 
 ### Granite guardian models
 

--- a/resources/ollama/granite3.3-vision/README.md
+++ b/resources/ollama/granite3.3-vision/README.md
@@ -1,4 +1,4 @@
-<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="200" /></center>
+<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="600" /></center>
 
 ### Granite 3.3 Vision models
 

--- a/resources/ollama/granite3.3/README.md
+++ b/resources/ollama/granite3.3/README.md
@@ -1,4 +1,4 @@
-<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="200" /></center>
+<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="600" /></center>
 
 ### Granite 3.3 models
 

--- a/resources/ollama/granite4.0-preview/README.md
+++ b/resources/ollama/granite4.0-preview/README.md
@@ -1,4 +1,4 @@
-<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="200" /></center>
+<center><img src="https://ollama.com/assets/library/granite3.2/90c5e567-0004-425c-a17a-1b846c2b5d3d" data-canonical-src="https://gyazo.com/eb5c5741b6a9a16c692170a41a49c858.png" width="600" /></center>
 
 ### Granite-4.0 models (preview)
 


### PR DESCRIPTION
## Description

The top-level Ollama READMEs use a width of 600 for the banner image, so this matches that